### PR TITLE
Secure Kafka demo profile with TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Adds Filebeat and Logstash for advanced log processing.
 docker compose --profile kafka up -d
 ```
 
-Adds Apache Kafka along with dedicated Logstash pipelines that publish data into Kafka and deliver the messages back into Elasticsearch. The broker is secured with TLS using the stack-generated certificate authority, so clients reuse the shared `certs/` volume. Drop files into the `logstash_ingest_data/` directory to see them flow through Kafka into the `kafka-demo-*` indices.
+Adds Apache Kafka along with dedicated Logstash pipelines that publish data into Kafka and deliver the messages back into Elasticsearch. The broker is secured with TLS using the stack-generated certificate authority, so clients reuse the shared `certs/` volume. During setup the Kafka server certificate is chained with the Elasticsearch CA to keep every service on the same trust path. Drop files into the `logstash_ingest_data/` directory to see them flow through Kafka into the `kafka-demo-*` indices.
 
 > **Tip:** Override the default Kafka settings by adding `KAFKA_PORT` or `KAFKA_TOPIC` entries to your `.env` file before running Docker Compose. The TLS listener defaults to `9093`.
 

--- a/README.md
+++ b/README.md
@@ -290,6 +290,16 @@ docker compose --profile filebeat --profile logstash up -d
 
 Adds Filebeat and Logstash for advanced log processing.
 
+### With Kafka Log Routing Demo
+
+```bash
+docker compose --profile kafka up -d
+```
+
+Adds Apache Kafka along with dedicated Logstash pipelines that publish data into Kafka and deliver the messages back into Elasticsearch. The broker is secured with TLS using the stack-generated certificate authority, so clients reuse the shared `certs/` volume. Drop files into the `logstash_ingest_data/` directory to see them flow through Kafka into the `kafka-demo-*` indices.
+
+> **Tip:** Override the default Kafka settings by adding `KAFKA_PORT` or `KAFKA_TOPIC` entries to your `.env` file before running Docker Compose. The TLS listener defaults to `9093`.
+
 ### Air-Gapped Deployment
 
 ```bash
@@ -651,6 +661,7 @@ docker compose --profile filebeat --profile logstash up -d
 - **Agent Testing**: `docker compose --profile agent up -d` for agent functionality
 - **ML Testing**: `docker compose --profile ml up -d` for machine learning features
 - **Multiple Profiles**: `docker compose --profile apm --profile monitoring --profile filebeat up -d` for comprehensive testing
+- **Kafka Demo**: `docker compose --profile kafka up -d` to route sample files through Kafka into Elasticsearch
 
 ## Contributing
 

--- a/config/logstash-kafka-in.conf
+++ b/config/logstash-kafka-in.conf
@@ -1,0 +1,25 @@
+input {
+  file {
+    path => "/usr/share/logstash/ingest_data/*"
+    start_position => "beginning"
+    mode => "read"
+    sincedb_path => "/usr/share/logstash/data/plugins/inputs/file/logstash-kafka-in.sincedb"
+  }
+}
+
+filter {
+}
+
+output {
+  kafka {
+    bootstrap_servers => "${KAFKA_BOOTSTRAP_SERVERS}"
+    topic_id => "${KAFKA_TOPIC}"
+    codec => json
+    security_protocol => "SSL"
+    ssl_ca_cert => "/usr/share/logstash/certs/ca/ca.crt"
+  }
+
+  stdout {
+    codec => json_lines
+  }
+}

--- a/config/logstash-kafka-out.conf
+++ b/config/logstash-kafka-out.conf
@@ -1,0 +1,27 @@
+input {
+  kafka {
+    bootstrap_servers => "${KAFKA_BOOTSTRAP_SERVERS}"
+    topics => ["${KAFKA_TOPIC}"]
+    auto_offset_reset => "earliest"
+    codec => json
+    security_protocol => "SSL"
+    ssl_ca_cert => "/usr/share/logstash/certs/ca/ca.crt"
+  }
+}
+
+filter {
+}
+
+output {
+  elasticsearch {
+    index => "kafka-demo-%{+YYYY.MM.dd}"
+    hosts => "${ELASTIC_HOSTS}"
+    user => "${ELASTIC_USER}"
+    password => "${ELASTIC_PASSWORD}"
+    ssl_certificate_authorities => "certs/ca/ca.crt"
+  }
+
+  stdout {
+    codec => json_lines
+  }
+}

--- a/examples.yml
+++ b/examples.yml
@@ -319,7 +319,7 @@ services:
       - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=SSL
       - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
       - KAFKA_TLS_TYPE=PEM
-      - KAFKA_TLS_CERTIFICATE_FILE=/certs/kafka/kafka.crt
+      - KAFKA_TLS_CERTIFICATE_FILE=/certs/kafka/kafka.chain.pem
       - KAFKA_TLS_KEY_FILE=/certs/kafka/kafka.key
       - KAFKA_TLS_CA_CERT_FILE=/certs/ca/ca.crt
       - KAFKA_CFG_SSL_CLIENT_AUTH=none

--- a/examples.yml
+++ b/examples.yml
@@ -12,6 +12,14 @@ volumes:
     driver: local
   logstashdata01:
     driver: local
+  logstashdata_kafka_in:
+    driver: local
+  logstashdata_kafka_out:
+    driver: local
+  kafkadata01:
+    driver: local
+  zookeeperdata01:
+    driver: local
 
 services:
   # The ml01 is configured to be a dedicated ML node within the cluster large enough to download and install the ELSER model
@@ -277,10 +285,96 @@ services:
         [
           "CMD-SHELL",
           "curl -s --cacert /usr/share/logstash/certs/ca/ca.crt https://es01:9200 | grep -q 'missing authentication credentials'",
-        ]
+      ]
       interval: 10s
       timeout: 10s
       retries: 120
+
+  # Kafka demo profile adds Kafka and two Logstash pipelines to showcase ingesting data through Kafka
+  zookeeper:
+    profiles:
+      - kafka
+    image: bitnami/zookeeper:3.9
+    restart: unless-stopped
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+    volumes:
+      - zookeeperdata01:/bitnami/zookeeper
+
+  kafka:
+    profiles:
+      - kafka
+    image: bitnami/kafka:3.7
+    restart: unless-stopped
+    depends_on:
+      zookeeper:
+        condition: service_started
+    ports:
+      - ${KAFKA_PORT:-9093}:9093
+    environment:
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_CFG_LISTENERS=SSL://:9093
+      - KAFKA_CFG_ADVERTISED_LISTENERS=SSL://kafka:9093
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=SSL:SSL
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=SSL
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+      - KAFKA_TLS_TYPE=PEM
+      - KAFKA_TLS_CERTIFICATE_FILE=/certs/kafka/kafka.crt
+      - KAFKA_TLS_KEY_FILE=/certs/kafka/kafka.key
+      - KAFKA_TLS_CA_CERT_FILE=/certs/ca/ca.crt
+      - KAFKA_CFG_SSL_CLIENT_AUTH=none
+    volumes:
+      - certs:/certs
+      - kafkadata01:/bitnami/kafka
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "openssl s_client -connect localhost:9093 -servername kafka -CAfile /certs/ca/ca.crt </dev/null >/dev/null 2>&1",
+        ]
+      interval: 10s
+      timeout: 10s
+      retries: 30
+
+  logstash-kafka-in:
+    profiles:
+      - kafka
+    image: docker.elastic.co/logstash/logstash:${STACK_VERSION}
+    restart: unless-stopped
+    depends_on:
+      kafka:
+        condition: service_healthy
+    volumes:
+      - certs:/usr/share/logstash/certs
+      - logstashdata_kafka_in:/usr/share/logstash/data
+      - "./logstash_ingest_data/:/usr/share/logstash/ingest_data/"
+      - "./config/logstash-kafka-in.conf:/usr/share/logstash/pipeline/logstash.conf:ro"
+    environment:
+      - xpack.monitoring.enabled=false
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:9093
+      - KAFKA_TOPIC=${KAFKA_TOPIC:-elastic-logs}
+
+  logstash-kafka-out:
+    profiles:
+      - kafka
+    image: docker.elastic.co/logstash/logstash:${STACK_VERSION}
+    restart: unless-stopped
+    depends_on:
+      kafka:
+        condition: service_healthy
+      es01:
+        condition: service_healthy
+    volumes:
+      - certs:/usr/share/logstash/certs
+      - logstashdata_kafka_out:/usr/share/logstash/data
+      - "./config/logstash-kafka-out.conf:/usr/share/logstash/pipeline/logstash.conf:ro"
+    environment:
+      - xpack.monitoring.enabled=false
+      - ELASTIC_USER=elastic
+      - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
+      - ELASTIC_HOSTS=https://es01:9200
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:9093
+      - KAFKA_TOPIC=${KAFKA_TOPIC:-elastic-logs}
 
   # The webapp is an example insturmentation of the elastic APM agent. (Optional)
   # Access the webapp through http://localhost:8000

--- a/stack-setup.yml
+++ b/stack-setup.yml
@@ -63,6 +63,13 @@ services:
           "    ip:\n"\
           "      - 127.0.0.1\n"\
           "      - ${DOCKER_HOST_IP}\n"\
+          "  - name: kafka\n"\
+          "    dns:\n"\
+          "      - kafka\n"\
+          "      - localhost\n"\
+          "    ip:\n"\
+          "      - 127.0.0.1\n"\
+          "      - ${DOCKER_HOST_IP}\n"\
           "  - name: fleet-server\n"\
           "    dns:\n"\
           "      - fleet-server\n"\

--- a/stack-setup.yml
+++ b/stack-setup.yml
@@ -89,6 +89,7 @@ services:
           unzip config/certs/certs.zip -d config/certs;
         fi;
         cat config/certs/es01/es01.crt config/certs/ca/ca.crt > config/certs/es01/es01.chain.pem;
+        cat config/certs/kafka/kafka.crt config/certs/ca/ca.crt > config/certs/kafka/kafka.chain.pem;
         echo "Setting file permissions"
         chown -R root:root config/certs;
         find . -type d -exec chmod 755 \{\} \;;


### PR DESCRIPTION
## Summary
- secure the Kafka broker with TLS using the stack-generated certificate authority and update the compose profile
- configure the Logstash Kafka pipelines to connect over SSL with the shared CA bundle
- generate a Kafka certificate during setup and document the TLS listener defaults

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f166a3e5dc8329870449e366e58644